### PR TITLE
Set PACKAGE_NAME in `package.mk`

### DIFF
--- a/package.mk
+++ b/package.mk
@@ -1,3 +1,4 @@
+PACKAGE_NAME:=autocluster
 DEPS:=rabbitmq-server
 RELEASABLE:=true
 STANDALONE_TEST_COMMANDS:=autocluster_all_tests:run()


### PR DESCRIPTION
This is used by `rabbitmq-public-umbrella`. Without this, the plugin fails to build because it looks for `rabbitmq_autocluster.app.src`.