### PR TITLE
tuple/2 is an invalid typespec, use {} instead

### DIFF
--- a/src/autocluster_backend.erl
+++ b/src/autocluster_backend.erl
@@ -5,8 +5,8 @@
 %%==============================================================================
 -module(autocluster_backend).
 
--callback nodelist() -> tuple('ok', Nodes :: list())|tuple('error', Reason :: string()).
+-callback nodelist() -> {'ok', Nodes :: list()}|{'error', Reason :: string()}.
 
--callback register() -> 'ok'|tuple('error', Reason :: string()).
+-callback register() -> 'ok'|{'error', Reason :: string()}.
 
--callback unregister() -> 'ok'|tuple('error', Reason :: string()).
+-callback unregister() -> 'ok'|{'error', Reason :: string()}.


### PR DESCRIPTION
The error is reported by Erlang 18.0. Previous versions accepted it.