### PR TITLE
handle leading slashes in etcd keys

### DIFF
--- a/src/autocluster_etcd.erl
+++ b/src/autocluster_etcd.erl
@@ -147,6 +147,7 @@ extract_nodes(Miss) ->
 %% @doc Given an etcd key, return the erlang node name
 %% @end
 %%
+get_node_from_key(<<"/", V/binary>>) -> get_node_from_key(V);
 get_node_from_key(V) ->
   Path = string:concat(autocluster_httpc:build_path(lists:sublist(base_path(), 3, 2)), "/"),
   autocluster_util:node_name(string:substr(binary_to_list(V), length(Path))).

--- a/test/src/autocluster_etcd_tests.erl
+++ b/test/src/autocluster_etcd_tests.erl
@@ -22,6 +22,9 @@ base_path_test() ->
 get_node_from_key_test() ->
   ?assertEqual('rabbit@foo', autocluster_etcd:get_node_from_key(<<"rabbitmq/default/foo">>)).
 
+get_node_from_key_leading_slash_test() ->
+  ?assertEqual('rabbit@foo', autocluster_etcd:get_node_from_key(<<"/rabbitmq/default/foo">>)).
+
 node_path_test() ->
   autocluster_config_tests:reset_config(),
   [_, Node] = string:tokens(atom_to_list(node()), "@"),


### PR DESCRIPTION
When trying to use this with etcd, my cluster was trying to cluster with "rabbit@/ip-172-31-99-99.ec2.internal"  ... Notice the leading slash.  Looking at the test, the test etcd keys did not include the leading slash that all of my actual etcd keys included.  This should handle this situation.