### PR TITLE
Fix unregister for etcd

### DIFF
--- a/src/autocluster_etcd.erl
+++ b/src/autocluster_etcd.erl
@@ -31,7 +31,7 @@
 
 
 %% @spec init() -> ok
-%% @doc Kick of the Consul TTL health check pass timer
+%% @doc Kick off the etcd TTL health check pass timer
 %% @end
 %%
 init() ->
@@ -47,7 +47,7 @@ init() ->
 
 
 %% @spec nodelist() -> {ok, list()}|{error, Reason :: string()}
-%% @doc Return a list of nodes registered in Consul
+%% @doc Return a list of nodes registered in etcd
 %% @end
 %%
 nodelist() ->
@@ -79,11 +79,10 @@ register() -> ok.
 %%
 unregister() ->
   autocluster_log:info("Unregistering node with etcd"),
-  case autocluster_httpc:get(autocluster_config:get(consul_scheme),
-                             autocluster_config:get(consul_host),
-                             autocluster_config:get(consul_port),
-                             [v1, agent, service, deregister,
-                             autocluster_config:get(consul_service)], acl_args) of
+  case autocluster_httpc:delete(autocluster_config:get(etcd_scheme),
+                                autocluster_config:get(etcd_host),
+                                autocluster_config:get(etcd_port),
+                                node_path(), [{recursive, true}], []) of
     {ok, _} -> ok;
     Error   -> Error
   end.
@@ -97,10 +96,10 @@ set_etcd_node_key() ->
   autocluster_log:debug("Updated node registration with etcd"),
   Interval = autocluster_config:get(etcd_node_ttl),
   case autocluster_httpc:put(autocluster_config:get(etcd_scheme),
-                              autocluster_config:get(etcd_host),
-                              autocluster_config:get(etcd_port),
-                              node_path(), [{ttl, Interval}],
-                              "value=enabled") of
+                             autocluster_config:get(etcd_host),
+                             autocluster_config:get(etcd_port),
+                             node_path(), [{ttl, Interval}],
+                             "value=enabled") of
     {ok, _} -> ok;
     Error   -> Error
   end.
@@ -160,9 +159,9 @@ get_node_from_key(V) ->
 make_etcd_directory() ->
   autocluster_log:info("Creating etcd base path"),
   case autocluster_httpc:put(autocluster_config:get(etcd_scheme),
-                              autocluster_config:get(etcd_host),
-                              autocluster_config:get(etcd_port),
-                              base_path(), [{dir, true}], []) of
+                             autocluster_config:get(etcd_host),
+                             autocluster_config:get(etcd_port),
+                             base_path(), [{dir, true}], []) of
     {ok, _} -> ok;
     Error   -> Error
   end.

--- a/src/autocluster_httpc.erl
+++ b/src/autocluster_httpc.erl
@@ -147,6 +147,26 @@ put(Scheme, Host, Port, Path, Args, Body) ->
   parse_response(Response).
 
 
+%% @public
+%% @spec delete(Scheme, Host, Port, Path, Args, Body) -> Result
+%% @where Scheme = string(),
+%%        Host   = string(),
+%%        Port   = integer(),
+%%        Path   = string(),
+%%        Args   = proplist(),
+%%        Body   = string(),
+%%        Result = {ok, mixed}|{error, Reason::string()}
+%% @doc Perform a HTTP DELETE request
+%% @end
+%%
+delete(Scheme, Host, Port, Path, Args, Body) ->
+  URL = build_uri(Scheme, Host, Port, Path, Args),
+  autocluster_log:debug("DELETE ~s [~p]", [URL, Body]),
+  Response = httpc:request(delete, {URL, [], ?CONTENT_URLENCODED, Body}, [], []),
+  autocluster_log:debug("Response: [~p]", [Response]),
+  parse_response(Response).
+
+
 %% @private
 %% @spec decode_body(mixed) -> list()
 %% @doc Decode the response body and return a list


### PR DESCRIPTION
Doesn't seem like `unregister` is actually ever called, but I thought I'd fix the function in the `etcd` adapter anyway.