### PR TITLE
fail_onerror to support rabbitmq fail to start on error when node reg…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,17 +58,17 @@ qualified names to identify nodes.
 
 **Fail on error Support**
 
-When set to ``true`` this will cause newly joining RabbitMQ node fail to start on error when registering node with consul, etcd, or dns, or joining existing cluster. *(optional)*
+When set to ``stop`` this will cause newly joining RabbitMQ node stop on error when registering node with consul, etcd, or dns, or joining existing cluster. Valid values are ``stop`` and ``ignore`` *(optional)*
 
-+----------------------+------------------------------+
-| Environment Variable | ``AUTOCLUSTER_FAIL_ONERROR`` |
-+----------------------+------------------------------+
-| Setting Key          | ``longname``                 |
-+----------------------+------------------------------+
-| Data type            | ``bool``                     |
-+----------------------+------------------------------+
-| Default Value        | ``false``                    |
-+----------------------+------------------------------+
++----------------------+------------------------------------------------+
+| Environment Variable | ``AUTOCLUSTER_CLUSTER_FORMATION_FAILURE_MODE`` |
++----------------------+------------------------------------------------+
+| Setting Key          | ``cluster_formation_failure_mode``             |
++----------------------+------------------------------------------------+
+| Data type            | ``string``                                     |
++----------------------+------------------------------------------------+
+| Default Value        | ``ignore``                                     |
++----------------------+------------------------------------------------+
 
 **RabbitMQ Cluster Name**
 

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,20 @@ qualified names to identify nodes.
 | Default Value        | ``false``                 |
 +----------------------+---------------------------+
 
+**Fail on error Support**
+
+When set to ``true`` this will cause newly joining RabbitMQ node fail to start on error when registering node with consul, etcd, or dns, or joining existing cluster. *(optional)*
+
++----------------------+------------------------------+
+| Environment Variable | ``AUTOCLUSTER_FAIL_ONERROR`` |
++----------------------+------------------------------+
+| Setting Key          | ``longname``                 |
++----------------------+------------------------------+
+| Data type            | ``bool``                     |
++----------------------+------------------------------+
+| Default Value        | ``false``                    |
++----------------------+------------------------------+
+
 **RabbitMQ Cluster Name**
 
 A RabbitMQ cluster name to restrict the cluster membership to (optional). This only

--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -10,7 +10,7 @@
         [{config, backend,               "AUTOCLUSTER_TYPE",      consul,      atom,    false},
          {config, autocluster_host,      "AUTOCLUSTER_HOST",      "undefined", string,  false},
          {config, longname,              "RABBITMQ_USE_LONGNAME", false,       atom,    false},
-         {config, fail_onerror,          "AUTOCLUSTER_FAIL_ONERROR", false,    atom,    false},
+         {config, cluster_formation_failure_mode, "AUTOCLUSTER_CLUSTER_FORMATION_FAILURE_MODE", "ignore", string, false},
          {config, node_type,             "RABBITMQ_NODE_TYPE",    disc,        atom,    false},
          {config, cluster_name,          "CLUSTER_NAME",          "undefined", string,  false},
          {config, consul_acl,            "CONSUL_ACL",            "undefined", string,  false},

--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -10,6 +10,7 @@
         [{config, backend,               "AUTOCLUSTER_TYPE",      consul,      atom,    false},
          {config, autocluster_host,      "AUTOCLUSTER_HOST",      "undefined", string,  false},
          {config, longname,              "RABBITMQ_USE_LONGNAME", false,       atom,    false},
+         {config, fail_onerror,          "AUTOCLUSTER_FAIL_ONERROR", false,    atom,    false},
          {config, node_type,             "RABBITMQ_NODE_TYPE",    disc,        atom,    false},
          {config, cluster_name,          "CLUSTER_NAME",          "undefined", string,  false},
          {config, consul_acl,            "CONSUL_ACL",            "undefined", string,  false},

--- a/src/autocluster.erl
+++ b/src/autocluster.erl
@@ -28,7 +28,10 @@ init() ->
     {ok, DiscoveryNodes} -> ensure_clustered(DiscoveryNodes);
     error ->
       autocluster_log:info("Error in ensuring clustered"),
-      ok
+      case autocluster_config:get(fail_onerror) of
+        true -> error;
+        false -> ok
+      end
   end.
 
 
@@ -134,7 +137,10 @@ join_cluster(Nodes) ->
     [] ->
       autocluster_log:warning("Can not communicate with cluster nodes: ~p",
         [Nodes]),
-      ok;
+      case autocluster_config:get(fail_onerror) of
+        true -> error;
+        false -> ok
+      end;
     Alive ->
       autocluster_log:debug("Joining existing cluster: ~p", [Alive]),
       application:stop(rabbit),

--- a/src/autocluster.erl
+++ b/src/autocluster.erl
@@ -28,9 +28,9 @@ init() ->
     {ok, DiscoveryNodes} -> ensure_clustered(DiscoveryNodes);
     error ->
       autocluster_log:info("Error in ensuring clustered"),
-      case autocluster_config:get(fail_onerror) of
-        true -> error;
-        false -> ok
+      case autocluster_config:get(cluster_formation_failure_mode) of
+        "stop" -> error;
+        "ignore" -> ok
       end
   end.
 
@@ -137,9 +137,9 @@ join_cluster(Nodes) ->
     [] ->
       autocluster_log:warning("Can not communicate with cluster nodes: ~p",
         [Nodes]),
-      case autocluster_config:get(fail_onerror) of
-        true -> error;
-        false -> ok
+      case autocluster_config:get(cluster_formation_failure_mode) of
+        "stop" -> error;
+        "ignore" -> ok
       end;
     Alive ->
       autocluster_log:debug("Joining existing cluster: ~p", [Alive]),

--- a/test/src/autocluster_config_tests.erl
+++ b/test/src/autocluster_config_tests.erl
@@ -52,3 +52,9 @@ config_docker_screws_with_envvar_test() ->
   reset_config(),
   os:putenv("CONSUL_PORT", "tcp://172.17.10.3:8501"),
   ?assertEqual(8501, autocluster_config:get(consul_port)).
+
+config_get_os_atom_value_test() ->
+  reset_config(),
+  os:putenv("AUTOCLUSTER_FAIL_ONERROR", "true"),
+  ?assertEqual(true, autocluster_config:get(fail_onerror)).
+

--- a/test/src/autocluster_config_tests.erl
+++ b/test/src/autocluster_config_tests.erl
@@ -55,6 +55,6 @@ config_docker_screws_with_envvar_test() ->
 
 config_get_os_atom_value_test() ->
   reset_config(),
-  os:putenv("AUTOCLUSTER_FAIL_ONERROR", "true"),
-  ?assertEqual(true, autocluster_config:get(fail_onerror)).
+  os:putenv("AUTOCLUSTER_CLUSTER_FORMATION_FAILURE_MODE", "stop"),
+  ?assertEqual(stop, autocluster_config:get(cluster_formation_failure_mode)).
 


### PR DESCRIPTION
…istering with consul/etcd/dns or joining existing cluster.

fixes #41 . However still need to add support for N retries before declaring error.