### PR TITLE
Plugin can't register Service in Consul with enabled ACL

### DIFF
--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -133,7 +133,7 @@ unregister() ->
 acl_args() ->
   case autocluster_config:get(consul_acl) of
     "undefined" -> [];
-    ACL         -> [{acl, ACL}]
+    ACL         -> [{token, ACL}]
   end.
 
 


### PR DESCRIPTION
Hello,

current plugin version has bug that not allow to configure cluster based on Consul with ACL enabled.
Plugins send registration request
```
 curl -X POST -H "Content-Type: application/json" \
     -d '{"ID": "rabbitmq", "Name":”rabbitmq”, "Port":”5672”, "Tags”:["rabbitmq”], "Check”:{"Notes":"RabbitMQ Auto-Cluster Plugin TTL Check","TTL":"30s"}}' \
     http://localhost:8500/v1/agent/service/register?acl=8131feea-c6e1-572d-98fe-0c040eb93e75; echo
```
and Consul refuse to register Service.

Conform Consul documentation https://www.consul.io/docs/agent/services.html
```
Services may also contain a token field to provide an ACL token. 
```
argument should be 'token', not 'acl'.

This PR fix this problem. In my env works correctly.