### PR TITLE
Fix etcd backend startup on fresh etcd

### DIFF
--- a/src/autocluster_etcd.erl
+++ b/src/autocluster_etcd.erl
@@ -58,7 +58,7 @@ nodelist() ->
     {ok, Nodes}  ->
       NodeList = extract_nodes(Nodes),
       {ok, NodeList};
-    {error, 404} ->
+    {error, "404"} ->
       ok = make_etcd_directory(),
       nodelist();
     Error        -> Error


### PR DESCRIPTION
Because `autocluster_httpc:parse_respnose/1` returns 404 as a
string.