### PR TITLE
Switched to full names in etcd + integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
   apt: true
   directories:
     - $HOME/.cache/plt
+    - $HOME/.cache/bin
 
 install:
   - pip install --user codecov
@@ -20,6 +21,16 @@ install:
 
 before_script:
   - git checkout -B "${TRAVIS_TAG:-${TRAVIS_BRANCH}}"
+  - |
+    if [ ! -e $HOME/.cache/bin/etcd ]; then
+      mkdir -p $HOME/.cache/bin
+      (set -e
+       cd $HOME/.cache/bin
+       curl -L https://github.com/coreos/etcd/releases/download/v2.3.7/etcd-v2.3.7-linux-amd64.tar.gz -o etcd.tar.gz
+       tar -xz --strip-components=1 -f etcd.tar.gz
+      )
+    fi
+    export USE_ETCD=$HOME/.cache/bin/etcd
 
 script:
   - make RABBITMQ_CURRENT_FETCH_URL=https://github.com/rabbitmq/rabbitmq-trick-erlang.mk-into-using-proper-url-for-deps

--- a/src/autocluster.erl
+++ b/src/autocluster.erl
@@ -260,8 +260,8 @@ join_cluster_nodes([]) ->
 
 join_cluster_nodes(Nodes) ->
   autocluster_log:debug("Joining the cluster."),
-  ok = application:stop(rabbit),
-  stopped = mnesia:stop(),
+  _ = application:stop(rabbit),
+  _ = mnesia:stop(),
   rabbit_mnesia:reset(),
   process_join_result(
     rabbit_mnesia:join_cluster(lists:nth(1, Nodes),

--- a/src/autocluster_etcd.erl
+++ b/src/autocluster_etcd.erl
@@ -168,10 +168,9 @@ make_etcd_directory() ->
   end.
 
 
-%% @spec node_path() -> list()
 %% @doc Return a list of path segments that are the base path for etcd key actions
 %% @end
 %%
+-spec node_path() -> [autocluster_httpc:path_component()].
 node_path() ->
-  [_, Node] = string:tokens(atom_to_list(node()), "@"),
-  lists:append(base_path(), [Node]).
+  base_path() ++ [atom_to_list(node())].

--- a/src/autocluster_httpc.erl
+++ b/src/autocluster_httpc.erl
@@ -23,12 +23,14 @@
 -define(CONTENT_JSON, "application/json").
 -define(CONTENT_URLENCODED, "application/x-www-form-urlencoded").
 
+-type path_component() :: atom() | binary() | integer() | string().
+-export_type([path_component/0]).
 
 %% @public
-%% @spec build_path(list()) -> string()
 %% @doc Build the path from a list of segments
 %% @end
 %%
+-spec build_path([path_component()]) -> string().
 build_path(Args) ->
   build_path(Args, []).
 

--- a/src/autocluster_sup.erl
+++ b/src/autocluster_sup.erl
@@ -48,7 +48,7 @@ start_link() ->
 -spec init(Args :: term()) ->
     {ok, {{RestartStrategy :: supervisor:strategy(),
            MaxR            :: non_neg_integer(),
-           MaxT            :: non_neg_integer()},
+           MaxT            :: pos_integer()},
            [ChildSpec :: supervisor:child_spec()]}}.
 init([]) ->
   Children = case autocluster_config:get(cluster_cleanup) of

--- a/src/autocluster_util.erl
+++ b/src/autocluster_util.erl
@@ -168,11 +168,19 @@ node_hostname() ->
 %% @end
 %%--------------------------------------------------------------------
 -spec node_name(Value :: atom() | binary() | string()) -> atom().
-node_name(Value) ->
-  list_to_atom(string:join([node_prefix(),
-                            node_name_parse(as_string(Value))],
-                           "@")).
-
+node_name(Value) when is_atom(Value) ->
+    node_name(atom_to_list(Value));
+node_name(Value) when is_binary(Value) ->
+    node_name(binary_to_list(Value));
+node_name(Value) when is_list(Value) ->
+  case lists:member($@, Value) of
+      true ->
+          list_to_atom(Value);
+      false ->
+          list_to_atom(string:join([node_prefix(),
+                                    node_name_parse(as_string(Value))],
+                                   "@"))
+  end.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/test/health_check_SUITE.erl
+++ b/test/health_check_SUITE.erl
@@ -1,0 +1,140 @@
+-module(health_check_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+%% common_test exports
+-export([all/0
+        ,groups/0
+        ,init_per_suite/1
+        ,end_per_suite/1
+        ,init_per_testcase/2
+        ,end_per_testcase/2
+        ]).
+
+%% test cases
+-export([cluster_is_assembled/1
+        ]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Common test callbacks
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+all() ->
+    optional(has_etcd(), {group, etcd_group}).
+
+groups() ->
+    optional(has_etcd(), {etcd_group, [], [cluster_is_assembled
+                                          ]}).
+
+init_per_suite(Config) ->
+    rabbit_ct_helpers:log_environment(),
+    rabbit_ct_helpers:run_setup_steps(Config).
+
+end_per_suite(Config) ->
+    rabbit_ct_helpers:run_teardown_steps(Config).
+
+init_per_testcase(cluster_is_assembled, Config0) ->
+    Config1 = [{rmq_nodes_count, 3}
+              ,{rmq_nodes_clustered, false}
+              ,{broker_with_plugins, true}
+               | Config0],
+    rabbit_ct_helpers:run_steps(Config1,
+                                [fun start_etcd/1
+                                ,fun generate_erlang_node_config/1
+                                ]
+                                ++ rabbit_ct_broker_helpers:setup_steps());
+
+init_per_testcase(_, Config) ->
+    Config.
+
+end_per_testcase(cluster_is_assembled, Config) ->
+    rabbit_ct_helpers:run_steps(Config,
+                                rabbit_ct_broker_helpers:teardown_steps()
+                                ++ [fun stop_etcd/1]);
+
+end_per_testcase(_, Config) ->
+    Config.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Test cases
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+cluster_is_assembled(Config) ->
+    ExpectedNodes = lists:sort(rabbit_ct_broker_helpers:get_node_configs(Config, nodename)),
+    case lists:sort(rabbit_ct_broker_helpers:rpc(Config, 1, rabbit_mnesia, cluster_nodes, [running])) of
+        ExpectedNodes ->
+            ok;
+        GotNodes ->
+            ct:pal(error, "Nodes in cluster are ~p when ~p was expected", [GotNodes, ExpectedNodes])
+    end,
+    ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Helpers
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+has_etcd() ->
+    case os:getenv("USE_ETCD") of
+        false ->
+            false;
+        _ ->
+            true
+    end.
+
+find_etcd_executable(_Config) ->
+    os:getenv("USE_ETCD").
+
+%% XXX Think about implementing etcd stub. But given that etcd is just
+%% a statically linked easily downloadable binary, it may be not worth
+%% it.
+start_etcd(Config) ->
+    Exe = find_etcd_executable(Config),
+    Dir = filename:join(?config(priv_dir, Config), "etcd.data"),
+    ok = file:make_dir(Dir),
+    {ok, Port} = exec_background([Exe, "--data-dir", Dir]),
+    [{etcd_erlang_port, Port},
+     {etcd_port, 2379}
+     |Config].
+
+stop_etcd(Config) ->
+    Port = ?config(etcd_erlang_port, Config),
+    {os_pid, OsPid} = erlang:port_info(Port, os_pid),
+    os:cmd(io_lib:format("kill -9 ~p", [OsPid])),
+    Config.
+
+%% XXX Do something of a sort in rabbit_ct_helpers.
+exec_background([Cmd|Args]) ->
+    PortOptions = [use_stdio, stderr_to_stdout],
+    Port = erlang:open_port({spawn_executable, Cmd},
+                            [{args, Args}, exit_status | PortOptions]),
+    ct:pal(?LOW_IMPORTANCE, "Started port ~p for command ~p", [Port, [Cmd|Args]]),
+    spawn_link(fun() -> background_port_loop(Port) end),
+    {ok, Port}.
+
+background_port_loop(Port) ->
+    receive
+        {Port, {exit_status, X}} ->
+            ct:pal(?LOW_IMPORTANCE, "Port ~p exited with ~b", [Port, X]);
+        {Port, {data, Data}} ->
+            ct:pal(?LOW_IMPORTANCE, "Port ~p data: ~s~n", [Port, Data]),
+            background_port_loop(Port)
+    end.
+
+-spec optional(boolean(), Val) -> [Val] when Val :: term().
+optional(true, Value) ->
+    [Value];
+optional(false, _) ->
+    [].
+
+generate_erlang_node_config(Config) ->
+    ErlangNodeConfig = [{rabbit, [{dummy_param_for_comma, true}
+                                 ,{cluster_partition_handling, ignore}
+                                 ]},
+                        {autocluster, [{dummy_param_for_comma, true}
+                                      ,{backend, etcd}
+                                      ,{autocluster_failure, stop}
+                                      ,{cleanup_interval, 10}
+                                      ,{cluster_cleanup, true}
+                                      ,{cleanup_warn_only, false}
+                                      ,{etcd_scheme, http}
+                                      ,{etcd_host, "localhost"}
+                                      ,{etcd_port, ?config(etcd_port, Config)}
+                                      ]}],
+    rabbit_ct_helpers:merge_app_env(Config, ErlangNodeConfig).

--- a/test/src/autocluster_etcd_tests.erl
+++ b/test/src/autocluster_etcd_tests.erl
@@ -27,8 +27,7 @@ get_node_from_key_leading_slash_test() ->
 
 node_path_test() ->
   autocluster_testing:reset(),
-  [_, Node] = string:tokens(atom_to_list(node()), "@"),
-  Expectation = [v2, keys, "rabbitmq", "default", Node],
+  Expectation = [v2, keys, "rabbitmq", "default", atom_to_list(node())],
   ?assertEqual(Expectation, autocluster_etcd:node_path()).
 
 nodelist_without_existing_directory_test_() ->

--- a/test/unit_test_SUITE.erl
+++ b/test/unit_test_SUITE.erl
@@ -1,13 +1,51 @@
 -module(unit_test_SUITE).
 
--export([all/0]).
-
--export([unit_tests/1]).
-
 -include_lib("common_test/include/ct.hrl").
 
-all() ->
-    [unit_tests].
+-export([all/0]).
 
-unit_tests(_Config) ->
-    autocluster_all_tests:run().
+-export([autocluster_config_tests/1
+        ,autocluster_consul_tests/1
+        ,autocluster_dns_tests/1
+        ,autocluster_etcd_tests/1
+        ,autocluster_httpc_tests/1
+        ,autocluster_sup_tests/1
+        ,autocluster_util_tests/1
+        ,autocluster_boot_tests/1
+        ]).
+
+
+all() ->
+    [autocluster_config_tests
+    ,autocluster_consul_tests
+    ,autocluster_dns_tests
+    ,autocluster_etcd_tests
+    ,autocluster_httpc_tests
+    ,autocluster_sup_tests
+    ,autocluster_util_tests
+    ,autocluster_boot_tests
+    ].
+
+autocluster_config_tests(_Config) ->
+    ok = eunit:test(autocluster_config_tests, [verbose]).
+
+autocluster_consul_tests(_Config) ->
+    ok = eunit:test(autocluster_consul_tests, [verbose]).
+
+autocluster_dns_tests(_Config) ->
+    ok = eunit:test(autocluster_dns_tests, [verbose]).
+
+autocluster_etcd_tests(_Config) ->
+    ok = eunit:test(autocluster_etcd_tests, [verbose]).
+
+autocluster_httpc_tests(_Config) ->
+    ok = eunit:test(autocluster_httpc_tests, [verbose]).
+
+autocluster_sup_tests(_Config) ->
+    ok = eunit:test(autocluster_sup_tests, [verbose]).
+
+autocluster_util_tests(_Config) ->
+    ok = eunit:test(autocluster_util_tests, [verbose]).
+
+autocluster_boot_tests(_Config) ->
+    ok = eunit:test(autocluster_boot_tests, [verbose]).


### PR DESCRIPTION
- Switched etcd backend to using full node names instead of common
  shared node prefix. There are 2 reasons for this change:
  - Openining path for simple node lifecycle management when we want
    truly transient nodes. By varying first part of nodename we can be
    sure that node is always joining a cluster for a first time -
    i.e. we don't need to check whether we were already clustered,
    call `forget_cluster_node` or invent some other recovery mechanism.
  - Simplifiyng testing using existing rabbit ct framework
- Added simple integration test for etcd backend
- Uncovered and fixed a bug introduced by #80
- Split unit tests into separate test cases, for better error reporting