### PR TITLE
DO NOT MERGE Use separate plugin for AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ rebar.lock
 cobertura.xml
 *.tgz
 _build
+/apps/autocluster_aws/autocluster_aws.d

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ after_success:
 before_deploy:
   - make clean
   - make dist
-  - tar cvfz autocluster-${TRAVIS_TAG}.tgz plugins/autocluster-${TRAVIS_TAG}.ez plugins/rabbitmq_aws-*.ez
+  - tar cvfz autocluster-${TRAVIS_TAG}.tgz plugins/autocluster*.ez plugins/rabbitmq_aws-*.ez
   - echo "TRAVIS_OTP_RELEASE = ${TRAVIS_OTP_RELEASE}"
 
 deploy:

--- a/apps/autocluster_aws/Makefile
+++ b/apps/autocluster_aws/Makefile
@@ -1,0 +1,12 @@
+PROJECT = autocluster_aws
+
+DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
+
+# FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
+# reviewed and merged.
+
+ERLANG_MK_REPO = https://github.com/rabbitmq/erlang.mk.git
+ERLANG_MK_COMMIT = rabbitmq-tmp
+
+include ../../rabbitmq-components.mk
+include ../../erlang.mk

--- a/apps/autocluster_aws/src/autocluster_aws.app.src
+++ b/apps/autocluster_aws/src/autocluster_aws.app.src
@@ -1,0 +1,7 @@
+{application,autocluster_aws,
+             [{description,"Autocluster AWS bundle"},
+              {vsn,"0.0.1"},
+              {modules,[]},
+              {registered,[]},
+              {env,[]},
+              {applications,[rabbitmq_aws,autocluster]}]}.

--- a/src/autocluster.app.src
+++ b/src/autocluster.app.src
@@ -20,6 +20,6 @@
       autocluster_sup,
       autocluster_util]},
     {registered, [autocluster_app, autocluster_sup, autocluster_cleanup]},
-    {applications, [kernel, stdlib, ssl, rabbit, inets, rabbitmq_aws]}
+    {applications, [kernel, stdlib, ssl, rabbit, inets]}
   ]
 }.

--- a/src/autocluster.erl
+++ b/src/autocluster.erl
@@ -59,7 +59,7 @@ node_is_registered() ->
 -spec ensure_registered(atom()) -> ok | error.
 ensure_registered(aws) ->
   autocluster_log:debug("Using AWS backend"),
-  ensure_registered(aws, autocluster_aws);
+  ensure_registered(aws, autocluster_aws, [rabbitmq_aws]);
 
 ensure_registered(consul) ->
   autocluster_log:debug("Using consul backend"),
@@ -96,6 +96,12 @@ ensure_registered(Backend) ->
 -spec ensure_registered(Name :: atom(), Module :: module())
     -> ok | error.
 ensure_registered(Name, Module) ->
+  ensure_registered(Name, Module, []).
+
+-spec ensure_registered(Name :: atom(), Module :: atom(), Apps :: [atom()])
+    -> ok | error.
+ensure_registered(Name, Module, Apps) ->
+  _ = [ application:ensure_all_started(App) || App <- Apps ],
   maybe_delay_startup(),
   autocluster_log:info("Starting ~p registration.", [Name]),
   Nodes = Module:nodelist(),


### PR DESCRIPTION
WDYT?
Fixes #99 
Probably fixes #63 
Requires https://github.com/rabbitmq/rabbitmq-common/pull/141

Enabling AWS backend now requires enabling just `autocluster_aws`
plugin  (`rabbitmq_aws` and `autocluster` will be loaded by rabbitmq
automatically).

The same approach will work for any other backend with external
dependences.
