### PR TITLE
Change gethostbyaddr implementation for DNS mode

### DIFF
--- a/src/autocluster_dns.erl
+++ b/src/autocluster_dns.erl
@@ -47,7 +47,7 @@ unregister() -> ok.
 %%
 build_node_list() ->
   Name = autocluster_config:get(autocluster_host),
-  Hosts = [extract_host(inet_res:gethostbyaddr(A)) || A <- inet_res:lookup(Name, in, a)],
+  Hosts = [extract_host(inet:gethostbyaddr(A)) || A <- inet_res:lookup(Name, in, a)],
   lists:filter(fun(E) -> E =/= error end, Hosts).
 
 


### PR DESCRIPTION
`inet_res:gethostbyaddr` does not take into account all inetrc configurations passed to Erlang, but using `inet:gethostbyaddr` instead should however do that.