### PR TITLE
Consul long node name option

### DIFF
--- a/include/autocluster.hrl
+++ b/include/autocluster.hrl
@@ -31,12 +31,14 @@
          {config, consul_scheme,         "CONSUL_SCHEME",          "http",       string,  false},
          {config, consul_host,           "CONSUL_HOST",            "localhost",  string,  false},
          {config, consul_port,           "CONSUL_PORT",            8500,         integer, true},
+         {config, consul_domain,         "CONSUL_DOMAIN",          "consul",     string,  false},
          {config, consul_svc,            "CONSUL_SVC",             "rabbitmq",   string,  false},
          {config, consul_svc_addr,       "CONSUL_SVC_ADDR",        "undefined",  string,  false},
          {config, consul_svc_addr_auto,  "CONSUL_SVC_ADDR_AUTO",   false,        atom,    false},
          {config, consul_svc_addr_nic,   "CONSUL_SVC_ADDR_NIC",    "undefined",  string,  false},
          {config, consul_svc_port,       "CONSUL_SVC_PORT",        5672,         integer, true},
          {config, consul_svc_ttl,        "CONSUL_SVC_TTL",         30,           integer, false},
+         {config, consul_use_longname,   "CONSUL_USE_LONGNAME",    false,        atom,    false},
 
          {config, autocluster_host,      "AUTOCLUSTER_HOST",       "undefined",  string,  false}, %% DNS
 

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -180,7 +180,7 @@ extract_nodes([{struct, H}|T], Nodes) ->
     "" ->
       {struct, NodeData} = proplists:get_value(<<"Node">>, H),
       Node = proplists:get_value(<<"Node">>, NodeData),
-      autocluster_util:node_name(Node);
+      maybe_add_domain(autocluster_util:node_name(Node));
     Address ->
       autocluster_util:node_name(Address)
   end,
@@ -453,3 +453,21 @@ service_id(Service, Address) ->
 -spec service_ttl(TTL :: integer()) -> string().
 service_ttl(Value) ->
   autocluster_util:as_string(Value) ++ "s".
+
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Append Consul domain if long names are in use
+%% @end
+%%--------------------------------------------------------------------
+-spec maybe_add_domain(Domain :: atom()) -> atom().
+maybe_add_domain(Value) ->
+  case autocluster_config:get(consul_use_longname) of
+      true ->
+          list_to_atom(string:join([atom_to_list(Value),
+                                    "node",
+                                    autocluster_config:get(consul_domain)],
+                                   "."));
+      false -> Value
+  end.

--- a/test/src/autocluster_consul_tests.erl
+++ b/test/src/autocluster_consul_tests.erl
@@ -206,6 +206,31 @@ nodelist_test_() ->
           ?assertEqual(Expectation, autocluster_consul:nodelist()),
           ?assert(meck:validate(autocluster_httpc))
         end},
+      {"return result with consul long name",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(_, _, _, _, _) ->
+              Body = "[{\"Node\": {\"Node\": \"rabbit2\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit2\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]",
+              rabbit_misc:json_decode(Body)
+            end),
+          os:putenv("CONSUL_USE_LONGNAME", "true"),
+          Expectation = {ok,['rabbit@rabbit1.node.consul', 'rabbit@rabbit2.node.consul']},
+          ?assertEqual(Expectation, autocluster_consul:nodelist()),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
+      {"return result with long name and custom domain",
+        fun() ->
+          meck:expect(autocluster_httpc, get,
+            fun(_, _, _, _, _) ->
+              Body = "[{\"Node\": {\"Node\": \"rabbit2\", \"Address\": \"10.20.16.160\"}, \"Checks\": [{\"Node\": \"rabbit2\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit2\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}, {\"Node\": {\"Node\": \"rabbit1\", \"Address\": \"10.20.16.159\"}, \"Checks\": [{\"Node\": \"rabbit1\", \"CheckID\": \"service:rabbitmq\", \"Name\": \"Service \'rabbitmq\' check\", \"ServiceName\": \"rabbitmq\", \"Notes\": \"Connect to the port internally every 30 seconds\", \"Status\": \"passing\", \"ServiceID\": \"rabbitmq\", \"Output\": \"\"}, {\"Node\": \"rabbit1\", \"CheckID\": \"serfHealth\", \"Name\": \"Serf Health Status\", \"ServiceName\": \"\", \"Notes\": \"\", \"Status\": \"passing\", \"ServiceID\": \"\", \"Output\": \"Agent alive and reachable\"}], \"Service\": {\"Address\": \"\", \"Port\": 5672, \"ID\": \"rabbitmq\", \"Service\": \"rabbitmq\", \"Tags\": [\"amqp\"]}}]",
+              rabbit_misc:json_decode(Body)
+            end),
+          os:putenv("CONSUL_USE_LONGNAME", "true"),
+          os:putenv("CONSUL_DOMAIN", "mydomain"),
+          Expectation = {ok,['rabbit@rabbit1.node.mydomain', 'rabbit@rabbit2.node.mydomain']},
+          ?assertEqual(Expectation, autocluster_consul:nodelist()),
+          ?assert(meck:validate(autocluster_httpc))
+        end},
       {"return result with srv address",
         fun() ->
           meck:expect(autocluster_httpc, get,


### PR DESCRIPTION
This enhancement makes the plugin work in situations where node names, as registered with Consul, are not FQDN's but can be arbitrary unique strings (in my case it is EC2 "Name" tag which consists of environment, server role and instance id), and also where it is necessary to use long node names. `.node.<consul_domain>` is appended to the node names retrieved from Consul.

Originally I was going to enable this based on the value of `RABBITMQ_USE_LONGNAME`. However, as this would potentially break down in cases where nodes _are_ registered in the catalog with their FQDN's (e.g. `rabbit1.internal.domain` would become `rabbit1.internal.domain.node.consul`), it seemed appropriate to introduce a separate flag to enable the feature.



