### PR TITLE
Changed HTTP verbs to support Consul v1.0.0 API

### DIFF
--- a/src/autocluster.app.src
+++ b/src/autocluster.app.src
@@ -1,7 +1,7 @@
 {application, autocluster,
   [
     {description, "RabbitMQ Automatic Clustering Plugin"},
-    {vsn, "0.6.1"},
+    {vsn, "0.6.2"},
     {env, []},
     {mod, {autocluster_app, []}},
     {modules, [

--- a/src/autocluster_consul.erl
+++ b/src/autocluster_consul.erl
@@ -85,7 +85,7 @@ nodelist() ->
 register() ->
   case registration_body() of
     {ok, Body} ->
-      case autocluster_httpc:post(autocluster_config:get(consul_scheme),
+      case autocluster_httpc:put(autocluster_config:get(consul_scheme),
                                   autocluster_config:get(consul_host),
                                   autocluster_config:get(consul_port),
                                   [v1, agent, service, register],
@@ -105,11 +105,11 @@ register() ->
 -spec send_health_check_pass() -> ok.
 send_health_check_pass() ->
   Service = string:join(["service", service_id()], ":"),
-  case autocluster_httpc:get(autocluster_config:get(consul_scheme),
+  case autocluster_httpc:put(autocluster_config:get(consul_scheme),
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, check, pass, Service],
-                             maybe_add_acl([])) of
+                             maybe_add_acl([]), "") of
     {ok, []} -> ok;
     {error, Reason} ->
       autocluster_log:error("Error updating Consul health check: ~p",
@@ -126,11 +126,11 @@ send_health_check_pass() ->
 -spec unregister() -> ok | {error, Reason :: string()}.
 unregister() ->
   Service = string:join(["service", service_id()], ":"),
-  case autocluster_httpc:get(autocluster_config:get(consul_scheme),
+  case autocluster_httpc:put(autocluster_config:get(consul_scheme),
                              autocluster_config:get(consul_host),
                              autocluster_config:get(consul_port),
                              [v1, agent, service, deregister, Service],
-                             maybe_add_acl([])) of
+                             maybe_add_acl([]), "") of
     {ok, _} -> ok;
     Error   -> Error
   end.


### PR DESCRIPTION
There are breaking changes in Consul v1.0.0 API that caused this plugin to stop working. This PR changes HTTP verbs to support updated Consul API. These changes will be incompatible with previous Consul versions.
https://github.com/hashicorp/consul/pull/3405/commits/cdd78fea7dab165a7bda0ce89d9b74083d838c44